### PR TITLE
Two issues fixed:

### DIFF
--- a/RobotDebug/RobotDebug.py
+++ b/RobotDebug/RobotDebug.py
@@ -44,7 +44,8 @@ class Listener:
 
         path = attrs["source"]
         if path and Path(path).exists() and path not in self.source_files:
-            self.source_files[path] = Path(path).open().readlines()
+            with open(Path(path)) as f:
+                self.source_files[path] = f.readlines()
         lineno = attrs["lineno"]
         self.library.current_source_path = path
         self.library.current_source_line = lineno

--- a/RobotDebug/robotlib.py
+++ b/RobotDebug/robotlib.py
@@ -44,7 +44,7 @@ class ImportedResourceDocBuilder(ResourceDocBuilder):
             type="RESOURCE",
             scope="GLOBAL",
         )
-        libdoc.keywords = KeywordDocBuilder().build_keywords(resource)
+        libdoc.keywords = KeywordDocBuilder(resource=True).build_keywords(resource)
         return libdoc
 
 


### PR DESCRIPTION
1. Gets rid of the warning messages in the command line about unclosed resource files (with the original implementation the stream is never closed)
2. We faced the issue with default values of keyword arguments - as soon as the debug library was activated all default values of arguments such as ${None}, ${True} etc. have been escaped (preceded with \\) hence logical conditions in our custom keywords did not work anymore.