### PR TITLE
Fix setup.py failing because of incorrect README name

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include ChangeLog
 include LICENSE
-include README.rst
+include readme.md
 
 # added by check-manifest
 include *.yml

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     name="robotframework-debug",
     version=find_version("RobotDebug/version.py"),
     description="RobotFramework debug shell",
-    long_description=Path("README.rst").read_text(),
+    long_description=Path("readme.md").read_text(),
     long_description_content_type=("text/x-rst"),
     author="René Rohner",
     author_email="snooz@postoe.de",


### PR DESCRIPTION
The README file was renamed from `README.rst` to `readme.md` in 368dedff9c03ea234962a789b5b60d5a0670cd22 but its usages were not all replaced, leading to

    FileNotFoundError: [Errno 2] No such file or directory: 'README.rst'

when trying to `pip install` the module.