### PR TITLE
Fix REPL exiting when keywords have no shortdoc

### DIFF
--- a/RobotDebug/debugcmd.py
+++ b/RobotDebug/debugcmd.py
@@ -160,7 +160,10 @@ Access https://github.com/imbus/robotframework-debug for more details.\
             if lib:
                 print_output("< Keywords of library", lib.name)
                 for keyword in get_lib_keywords(lib):
-                    print_output(f"   {keyword.name}\t", keyword.shortdoc)
+                    shortdoc = ""
+                    if hasattr(keyword, "shortdoc"):
+                        shortdoc = keyword.shortdoc.split("\n")[0]
+                    print_output(f"   {keyword.name}\t", shortdoc)
 
     do_k = do_keywords
 


### PR DESCRIPTION
The `keywords` command failed when there were keywords which don't have a shortdoc, causing the REPL to exit and the logs to show

    AttributeError: 'KeywordDoc' object has no attribute 'hasattr'

This change fixes that by only printing the shortdoc if there is one defined for the keyword.